### PR TITLE
fix: update release workflow to use PAT with bypass permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       with:
         fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.RELEASE_TOKEN }}
     
     - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v4.0.0
       with:


### PR DESCRIPTION
## Summary
Updates the release workflow to use a Personal Access Token with bypass permissions to resolve CI/CD failures caused by branch protection rules.

## Problem
The release workflow was failing with:
```
error: GH013: Repository rule violations found for refs/heads/main.
- Changes must be made through a pull request.
```

## Solution
Changed the workflow to use `RELEASE_TOKEN` instead of `GITHUB_TOKEN`. This requires setting up a PAT with Administration: Write permissions.

## Setup Required
Before merging, create a PAT and add it as a repository secret:

1. Go to https://github.com/settings/tokens?type=beta
2. Create a fine-grained PAT with:
   - Repository access: `rxreyn3/azure-devops-mcp`
   - Permissions:
     - ✅ Contents: Write
     - ✅ Metadata: Read
     - ✅ Pull requests: Write
     - ✅ Actions: Write
     - ✅ **Administration: Write** (enables bypass)
3. Add as repository secret named `RELEASE_TOKEN`

## Changes
- `.github/workflows/release.yml`: Updated checkout action to use `RELEASE_TOKEN`