### PR TITLE
fix: add write permissions to changesets workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -11,6 +11,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0


### PR DESCRIPTION
## Quick Fix

The changesets workflow failed with a permissions error:
```
remote: Permission to rxreyn3/azure-devops-mcp.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/rxreyn3/azure-devops-mcp/': The requested URL returned error: 403
```

This adds the required permissions:
- `contents: write` - To push branches and create releases
- `pull-requests: write` - To create the Version Packages PR

After merging this, the changesets workflow should successfully create the Version Packages PR.