### PR TITLE
feat: implement pipeline caching with full pagination support

### DIFF
--- a/.changeset/cute-impalas-hear.md
+++ b/.changeset/cute-impalas-hear.md
@@ -1,0 +1,5 @@
+---
+'@rxreyn3/azure-devops-mcp': minor
+---
+
+Implemented pipeline definition caching so that it's easier to discover pipelines based on partial names.

--- a/src/tools/agent-tools.ts
+++ b/src/tools/agent-tools.ts
@@ -7,7 +7,7 @@ export function createAgentTools(client: TaskAgentClient): Record<string, ToolDe
     ado_health_check: {
       tool: {
         name: 'ado_health_check',
-        description: 'Check connection to Azure DevOps and verify permissions',
+        description: 'Check connection to Azure DevOps and verify permissions. Use this to test your PAT token and ensure the server is properly configured.',
         inputSchema: {
           type: 'object',
           properties: {},
@@ -36,7 +36,7 @@ export function createAgentTools(client: TaskAgentClient): Record<string, ToolDe
     list_project_queues: {
       tool: {
         name: 'list_project_queues',
-        description: 'List all agent queues in the project',
+        description: 'List all agent queues available in the project. Returns queue IDs, names, and pool information. Queues are project-scoped views of agent pools.',
         inputSchema: {
           type: 'object',
           properties: {},
@@ -71,13 +71,13 @@ export function createAgentTools(client: TaskAgentClient): Record<string, ToolDe
     get_queue_details: {
       tool: {
         name: 'get_queue_details',
-        description: 'Get detailed information about a specific queue',
+        description: 'Get detailed information about a specific queue including pool details and agent count. Provides more context than list_project_queues.',
         inputSchema: {
           type: 'object',
           properties: {
             queueIdOrName: {
               type: 'string',
-              description: 'Queue ID (number) or name',
+              description: 'Queue ID (number) or name. Queue IDs are more reliable than names. Find IDs using list_project_queues.',
             },
           },
           required: ['queueIdOrName'],
@@ -108,13 +108,13 @@ export function createAgentTools(client: TaskAgentClient): Record<string, ToolDe
     find_agent: {
       tool: {
         name: 'find_agent',
-        description: 'Find which queue/pool an agent belongs to (requires org permissions)',
+        description: 'Find which queue/pool an agent belongs to (requires org-level permissions). Searches across all pools in the organization. May fail with project-scoped PAT.',
         inputSchema: {
           type: 'object',
           properties: {
             agentName: {
               type: 'string',
-              description: 'Name of the agent to find',
+              description: 'Name of the agent to find. Agent names are case-sensitive. Partial matches not supported.',
             },
           },
           required: ['agentName'],
@@ -142,13 +142,13 @@ export function createAgentTools(client: TaskAgentClient): Record<string, ToolDe
     list_queue_agents: {
       tool: {
         name: 'list_queue_agents',
-        description: 'List all agents in a queue (requires org permissions)',
+        description: 'List all agents in a specific queue (requires org-level permissions). Shows agent status, version, and capabilities. May fail with project-scoped PAT.',
         inputSchema: {
           type: 'object',
           properties: {
             queueId: {
               type: 'number',
-              description: 'Queue ID (not poolId) - use the queue\'s ID from list_project_queues',
+              description: 'Queue ID (not poolId). Must use the queue ID from list_project_queues, not the underlying pool ID.',
             },
           },
           required: ['queueId'],
@@ -183,21 +183,21 @@ export function createAgentTools(client: TaskAgentClient): Record<string, ToolDe
     list_agents: {
       tool: {
         name: 'list_agents',
-        description: 'List agents available in your project\'s pools with optional filtering',
+        description: 'List agents available in your project\'s pools with optional filtering. Shows agent status, version, and basic info. Works with project-scoped permissions.',
         inputSchema: {
           type: 'object',
           properties: {
             nameFilter: {
               type: 'string',
-              description: 'Filter agents by name (partial match, e.g., "BM40")',
+              description: 'Filter agents by name (partial match supported, e.g., "BM40"). Case-insensitive. Matches anywhere in agent name.',
             },
             poolNameFilter: {
               type: 'string',
-              description: 'Filter by pool name (partial match)',
+              description: 'Filter by pool name (partial match supported). Case-insensitive. Useful when you have multiple pools.',
             },
             onlyOnline: {
               type: 'boolean',
-              description: 'Only show online agents',
+              description: 'Only show online agents (default: false). Online agents are ready to run builds immediately.',
               default: false,
             },
           },

--- a/src/tools/pipeline-tools.ts
+++ b/src/tools/pipeline-tools.ts
@@ -10,21 +10,21 @@ export function createPipelineTools(client: BuildClient): Record<string, ToolDef
     list_pipelines: {
       tool: {
         name: 'list_pipelines',
-        description: 'List available build pipelines/definitions',
+        description: 'List available build pipelines/definitions. Returns pipeline IDs, names, paths, and status. Use includeLatestBuild to see recent activity.',
         inputSchema: {
           type: 'object',
           properties: {
             name: {
               type: 'string',
-              description: 'Filter by pipeline name (partial match)',
+              description: 'Filter by pipeline name. API uses exact match, but tool provides partial match by fetching all pipelines when filter is specified. Case-insensitive.',
             },
             path: {
               type: 'string',
-              description: 'Filter by folder path (use backslashes, e.g., "\\\\Apps\\\\Web")',
+              description: 'Filter by folder path (use double backslashes, e.g., "\\\\Apps\\\\Web"). Helps organize pipelines in large projects.',
             },
             includeLatestBuild: {
               type: 'boolean',
-              description: 'Include information about the latest build',
+              description: 'Include information about the latest build (default: false). Shows last build status and time for each pipeline.',
             },
           },
           required: [],
@@ -39,8 +39,7 @@ export function createPipelineTools(client: BuildClient): Record<string, ToolDef
         const result = await client.getDefinitions(
           typedArgs.name,
           typedArgs.path,
-          typedArgs.includeLatestBuild,
-          50
+          typedArgs.includeLatestBuild
         );
 
         if (!result.success) {
@@ -73,22 +72,22 @@ export function createPipelineTools(client: BuildClient): Record<string, ToolDef
     get_pipeline_config: {
       tool: {
         name: 'get_pipeline_config',
-        description: 'Get detailed pipeline/definition configuration',
+        description: 'Get detailed pipeline/definition configuration including variables, triggers, and repository settings. Essential for understanding pipeline behavior.',
         inputSchema: {
           type: 'object',
           properties: {
             definitionId: {
               type: 'number',
-              description: 'Pipeline definition ID',
+              description: 'Pipeline definition ID. Use list_pipelines to find pipeline IDs.',
             },
             includeVariables: {
               type: 'boolean',
-              description: 'Include variable definitions',
+              description: 'Include variable definitions (default: true). Shows pipeline variables but masks secret values.',
               default: true,
             },
             includeTriggers: {
               type: 'boolean',
-              description: 'Include trigger configuration',
+              description: 'Include trigger configuration (default: true). Shows CI triggers, branch filters, and PR validation settings.',
               default: true,
             },
           },
@@ -197,17 +196,17 @@ export function createPipelineTools(client: BuildClient): Record<string, ToolDef
     monitor_build_health: {
       tool: {
         name: 'monitor_build_health',
-        description: 'Get build health metrics and overview',
+        description: 'Get build health metrics and overview. Provides success rates, average durations, and failure patterns. Includes currently running builds.',
         inputSchema: {
           type: 'object',
           properties: {
             definitionId: {
               type: 'number',
-              description: 'Filter by specific pipeline definition ID',
+              description: 'Filter by specific pipeline definition ID (optional). Without this, shows metrics across all pipelines.',
             },
             hours: {
               type: 'number',
-              description: 'Number of hours to look back',
+              description: 'Number of hours to look back (default: 24). Longer periods provide better statistical accuracy.',
               default: 24,
             },
           },


### PR DESCRIPTION
## Summary

- Implements caching mechanism for pipeline definitions to improve performance and enable complete searches
- Fixes issue where only the first 50 pipelines were searchable

## Problem

Previously, the list_pipelines tool had several limitations:
- Only fetched first 50 pipelines by default
- Partial name matching only worked when explicitly searching
- Many pipelines were undiscoverable if they weren't in the most recent 50

## Solution

Implemented a comprehensive caching solution:
- Always fetch ALL pipeline definitions using continuation tokens
- Cache results for 5 minutes to balance freshness and performance
- Enable true partial name matching across entire pipeline collection
- Order results by LastModifiedDescending for better relevance

## Changes

- Add cache property and helper methods to BuildClient
- Implement refreshPipelineCache() method with full pagination
- Update getDefinitions() to use cache-first approach
- Update tool descriptions to accurately reflect API vs tool behavior

## Testing

Tested with the preflight pipeline search that was previously failing:
- Before: Found 0 preflight pipelines
- After: Found 3 preflight pipelines (including active ones)

The caching implementation successfully enables searching through all pipelines in the organization.