### PR TITLE
fix: improve capability error messages for MCP clients

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,8 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ListPromptsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { Config } from './config.js';
 import { TaskAgentClient } from './clients/task-agent-client.js';
@@ -27,10 +29,12 @@ export class AzureDevOpsMCPServer {
       {
         name: '@rxreyn3/azure-devops-mcp',
         version: packageJson.version,
+        description: 'MCP server for Azure DevOps agent, queue, and build management. Provides tools for interacting with Azure DevOps but does not support resources or prompts.',
       },
       {
         capabilities: {
           tools: {},
+          // Explicitly not supporting resources or prompts
         },
       },
     );
@@ -55,6 +59,23 @@ export class AzureDevOpsMCPServer {
 
       const result = await handler(args || {});
       return result as { content: Array<{ type: 'text'; text: string }> };
+    });
+
+    // Handle unsupported resources request with helpful error
+    this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
+      throw new Error(
+        'Server capability not supported: resources. This Azure DevOps MCP server only supports tools. ' +
+        'To discover available functionality, use the tools/list method instead. ' +
+        'Available tool examples: project_health_check, project_list_queues, build_list, org_list_agents, and 4 more.'
+      );
+    });
+
+    // Handle unsupported prompts request with helpful error
+    this.server.setRequestHandler(ListPromptsRequestSchema, async () => {
+      throw new Error(
+        'Server capability not supported: prompts. This Azure DevOps MCP server only supports tools. ' +
+        'To interact with Azure DevOps, use the tools/list method to discover available tools, then call them directly.'
+      );
     });
   }
 


### PR DESCRIPTION
## Summary
- Improves error messages when MCP clients attempt to use unsupported capabilities (resources/prompts)
- Adds descriptive serverInfo to clarify supported features during initialization
- Provides LLM-friendly error guidance that directs to the correct methods

## Problem
Clients encountering "failure listing resources: server azure-devops does not support resources" errors without clear guidance on how to proceed.

## Solution
1. Enhanced server initialization with descriptive info about supported capabilities
2. Added error handlers for `ListResourcesRequestSchema` and `ListPromptsRequestSchema`
3. Error messages now:
   - Clearly state what capability is not supported
   - Explain that only tools are supported
   - Direct clients to use the `tools/list` method
   - Provide examples of available tools

## Test plan
- [x] Build passes (`bun run build`)
- [x] Type checking passes (`bun run typecheck`)
- [ ] Test with MCP client to verify improved error messages
- [ ] Confirm error messages guide clients to correct method usage