### PR TITLE
docs: add security best practices for handling credentials

### DIFF
--- a/.changeset/lovely-islands-serve.md
+++ b/.changeset/lovely-islands-serve.md
@@ -1,0 +1,5 @@
+---
+'@rxreyn3/azure-devops-mcp': patch
+---
+
+Updated readme with sensitive key best practices.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,81 @@ This server provides tools with different scope requirements:
 
 > **Note**: Project-scoped PATs will only work with `project_*` and `build_*` tools. The `org_*` tools require organization-level access because agents are managed at the organization level in Azure DevOps.
 
+## Security Best Practices
+
+### ⚠️ Important: Handling Sensitive Credentials
+
+The `env` field in MCP client configurations (Claude Desktop, Claude Code, Windsurf) passes environment variables directly to the MCP server process. While convenient, **never share your configuration files** containing actual PAT values.
+
+### Recommended Approaches:
+
+1. **Direct Configuration (Simplest)**
+   - Add your credentials directly to the configuration file
+   - Keep the file secure and never commit it to version control
+   - This is suitable for personal use on trusted machines
+
+2. **Environment Variable Reference (Most Secure)**
+   - Some MCP clients support referencing system environment variables
+   - Set your credentials as system environment variables first:
+     ```bash
+     # macOS/Linux
+     export ADO_PAT="your-actual-pat-value"
+     
+     # Windows PowerShell
+     $env:ADO_PAT = "your-actual-pat-value"
+     ```
+   - Then reference them in your config (if supported by your client)
+
+3. **Configuration Management**
+   - Store a template configuration in version control with placeholder values
+   - Keep your actual configuration with real values locally
+   - Use `.gitignore` to prevent accidental commits
+
+### PAT Security Guidelines
+
+- **Create dedicated PATs** for MCP usage with minimal required permissions
+- **Set short expiration dates** and rotate regularly
+- **Use different PATs** for different projects or environments
+- **Never share PATs** in documentation, issues, or support requests
+- **Revoke immediately** if you suspect compromise
+
+### Platform-Specific Environment Variable Setup
+
+If you choose to use system environment variables:
+
+#### macOS/Linux
+```bash
+# Add to ~/.bashrc, ~/.zshrc, or ~/.profile
+export ADO_ORGANIZATION="https://dev.azure.com/your-organization"
+export ADO_PROJECT="your-project-name"
+export ADO_PAT="your-personal-access-token"
+
+# Apply changes
+source ~/.zshrc  # or source ~/.bashrc
+```
+
+#### Windows (PowerShell)
+```powershell
+# Set user environment variables (permanent)
+[System.Environment]::SetEnvironmentVariable("ADO_ORGANIZATION", "https://dev.azure.com/your-organization", "User")
+[System.Environment]::SetEnvironmentVariable("ADO_PROJECT", "your-project-name", "User")
+[System.Environment]::SetEnvironmentVariable("ADO_PAT", "your-personal-access-token", "User")
+
+# Restart your terminal for changes to take effect
+```
+
+#### Windows (Command Prompt)
+```cmd
+# Set user environment variables (permanent)
+setx ADO_ORGANIZATION "https://dev.azure.com/your-organization"
+setx ADO_PROJECT "your-project-name"
+setx ADO_PAT "your-personal-access-token"
+
+# Restart your terminal for changes to take effect
+```
+
+**Note**: Setting system environment variables is optional. The MCP client's `env` field will pass these values directly to the server process regardless of your system environment.
+
 ## Installation & Usage
 
 This MCP server can be used with Windsurf, Claude Desktop, and Claude Code. All methods use `npx` to run the package directly without installation.


### PR DESCRIPTION
## Summary
- Adds comprehensive security documentation for handling Azure DevOps PATs and other sensitive credentials
- Clarifies how the MCP `env` field works in client configurations
- Provides platform-specific guidance for environment variable setup

## Changes
- Added "Security Best Practices" section to README explaining:
  - How the `env` field passes environment variables to MCP servers
  - Three approaches for credential management (direct config, env vars, config management)
  - PAT-specific security guidelines for Azure DevOps
  - Platform-specific examples for macOS/Linux and Windows

## Context
Based on research of MCP documentation and best practices, the `env` field in MCP client configurations passes environment variables directly to the server process. This PR documents the security implications and provides clear guidance for users on how to safely manage their credentials.

The documentation emphasizes that the values shown in configuration examples are placeholders that must be replaced with actual credentials, and warns against committing real credentials to version control.