### PR TITLE
fix: remove unsupported resource and prompt handlers

### DIFF
--- a/.changeset/angry-mice-dig.md
+++ b/.changeset/angry-mice-dig.md
@@ -1,0 +1,5 @@
+---
+'@rxreyn3/azure-devops-mcp': patch
+---
+
+Removed list resources and list prompt handlers.

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,8 +3,6 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
-  ListResourcesRequestSchema,
-  ListPromptsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { Config } from './config.js';
 import { TaskAgentClient } from './clients/task-agent-client.js';
@@ -61,22 +59,6 @@ export class AzureDevOpsMCPServer {
       return result as { content: Array<{ type: 'text'; text: string }> };
     });
 
-    // Handle unsupported resources request with helpful error
-    this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
-      throw new Error(
-        'Server capability not supported: resources. This Azure DevOps MCP server only supports tools. ' +
-        'To discover available functionality, use the tools/list method instead. ' +
-        'Available tool examples: project_health_check, project_list_queues, build_list, org_list_agents, and 4 more.'
-      );
-    });
-
-    // Handle unsupported prompts request with helpful error
-    this.server.setRequestHandler(ListPromptsRequestSchema, async () => {
-      throw new Error(
-        'Server capability not supported: prompts. This Azure DevOps MCP server only supports tools. ' +
-        'To interact with Azure DevOps, use the tools/list method to discover available tools, then call them directly.'
-      );
-    });
   }
 
   async start(): Promise<void> {


### PR DESCRIPTION
## Summary
- Removed handlers for ListResourcesRequestSchema and ListPromptsRequestSchema
- Server now starts without runtime errors

## Problem
The server was attempting to register handlers for resources and prompts without declaring support for these capabilities in the server configuration. This caused the MCP SDK to throw a runtime error on startup:
```
Error: Server does not support resources (required for resources/list)
```

## Solution
Removed the unsupported handlers since the server only declares support for tools, not resources or prompts.

## Test plan
- [x] Build the project with `bun run build`
- [x] Run the server with `node dist/index.js` - it now starts successfully
- [x] Verify the server connects properly to Claude Code