### PR TITLE
feat: add BuildReason enum mapping for human-readable build reasons

### DIFF
--- a/.changeset/build-reason-mapping.md
+++ b/.changeset/build-reason-mapping.md
@@ -1,0 +1,5 @@
+---
+"@rxreyn3/azure-devops-mcp": patch
+---
+
+Add BuildReason enum mapping to convert numeric reason values to human-readable strings in build_list output

--- a/.changeset/friendly-enum-values.md
+++ b/.changeset/friendly-enum-values.md
@@ -1,0 +1,5 @@
+---
+"@rxreyn3/azure-devops-mcp": patch
+---
+
+Convert numeric state and result values to human-readable strings in build_list and build_get_timeline outputs

--- a/src/tools/build-tools.ts
+++ b/src/tools/build-tools.ts
@@ -1,6 +1,7 @@
 import { ToolDefinition } from '../types/tool-types.js';
 import { BuildClient } from '../clients/build-client.js';
 import { formatErrorResponse } from '../utils/formatters.js';
+import { mapBuildStatus, mapBuildResult, mapTimelineRecordState, mapTaskResult, mapBuildReason } from '../utils/enum-mappers.js';
 import * as BuildInterfaces from 'azure-devops-node-api/interfaces/BuildInterfaces.js';
 
 export function createBuildTools(client: BuildClient): Record<string, ToolDefinition> {
@@ -51,8 +52,8 @@ export function createBuildTools(client: BuildClient): Record<string, ToolDefini
               workerName: job.workerName,
               startTime: job.startTime,
               finishTime: job.finishTime,
-              state: job.state,
-              result: job.result,
+              state: mapTimelineRecordState(job.state),
+              result: mapTaskResult(job.result),
               percentComplete: job.percentComplete,
               id: job.id,
             })),
@@ -62,8 +63,8 @@ export function createBuildTools(client: BuildClient): Record<string, ToolDefini
               name: task.name,
               startTime: task.startTime,
               finishTime: task.finishTime,
-              state: task.state,
-              result: task.result,
+              state: mapTimelineRecordState(task.state),
+              result: mapTaskResult(task.result),
               percentComplete: task.percentComplete,
               parentId: task.parentId,
               id: task.id,
@@ -222,9 +223,9 @@ export function createBuildTools(client: BuildClient): Record<string, ToolDefini
             id: build.definition?.id,
             name: build.definition?.name,
           },
-          status: build.status,
-          result: build.result,
-          reason: build.reason,
+          status: mapBuildStatus(build.status),
+          result: mapBuildResult(build.result),
+          reason: mapBuildReason(build.reason),
           startTime: build.startTime,
           finishTime: build.finishTime,
           sourceBranch: build.sourceBranch,

--- a/src/utils/enum-mappers.ts
+++ b/src/utils/enum-mappers.ts
@@ -1,0 +1,127 @@
+import * as BuildInterfaces from 'azure-devops-node-api/interfaces/BuildInterfaces.js';
+
+/**
+ * Maps BuildStatus enum values to human-readable strings
+ */
+export function mapBuildStatus(status: BuildInterfaces.BuildStatus | undefined): string {
+  if (status === undefined || status === null) return 'Unknown';
+  
+  switch (status) {
+    case BuildInterfaces.BuildStatus.None:
+      return 'None';
+    case BuildInterfaces.BuildStatus.InProgress:
+      return 'InProgress';
+    case BuildInterfaces.BuildStatus.Completed:
+      return 'Completed';
+    case BuildInterfaces.BuildStatus.Cancelling:
+      return 'Cancelling';
+    case BuildInterfaces.BuildStatus.Postponed:
+      return 'Postponed';
+    case BuildInterfaces.BuildStatus.NotStarted:
+      return 'NotStarted';
+    case BuildInterfaces.BuildStatus.All:
+      return 'All';
+    default:
+      return `Unknown(${status})`;
+  }
+}
+
+/**
+ * Maps BuildResult enum values to human-readable strings
+ */
+export function mapBuildResult(result: BuildInterfaces.BuildResult | undefined): string {
+  if (result === undefined || result === null) return 'Unknown';
+  
+  switch (result) {
+    case BuildInterfaces.BuildResult.None:
+      return 'None';
+    case BuildInterfaces.BuildResult.Succeeded:
+      return 'Succeeded';
+    case BuildInterfaces.BuildResult.PartiallySucceeded:
+      return 'PartiallySucceeded';
+    case BuildInterfaces.BuildResult.Failed:
+      return 'Failed';
+    case BuildInterfaces.BuildResult.Canceled:
+      return 'Canceled';
+    default:
+      return `Unknown(${result})`;
+  }
+}
+
+/**
+ * Maps TimelineRecordState enum values to human-readable strings
+ */
+export function mapTimelineRecordState(state: BuildInterfaces.TimelineRecordState | undefined): string {
+  if (state === undefined || state === null) return 'Unknown';
+  
+  switch (state) {
+    case BuildInterfaces.TimelineRecordState.Pending:
+      return 'Pending';
+    case BuildInterfaces.TimelineRecordState.InProgress:
+      return 'InProgress';
+    case BuildInterfaces.TimelineRecordState.Completed:
+      return 'Completed';
+    default:
+      return `Unknown(${state})`;
+  }
+}
+
+/**
+ * Maps TaskResult enum values to human-readable strings
+ */
+export function mapTaskResult(result: BuildInterfaces.TaskResult | undefined): string {
+  if (result === undefined || result === null) return 'Unknown';
+  
+  switch (result) {
+    case BuildInterfaces.TaskResult.Succeeded:
+      return 'Succeeded';
+    case BuildInterfaces.TaskResult.SucceededWithIssues:
+      return 'SucceededWithIssues';
+    case BuildInterfaces.TaskResult.Failed:
+      return 'Failed';
+    case BuildInterfaces.TaskResult.Canceled:
+      return 'Canceled';
+    case BuildInterfaces.TaskResult.Skipped:
+      return 'Skipped';
+    case BuildInterfaces.TaskResult.Abandoned:
+      return 'Abandoned';
+    default:
+      return `Unknown(${result})`;
+  }
+}
+
+/**
+ * Maps BuildReason enum values to human-readable strings
+ */
+export function mapBuildReason(reason: BuildInterfaces.BuildReason | undefined): string {
+  if (reason === undefined || reason === null) return 'Unknown';
+  
+  switch (reason) {
+    case BuildInterfaces.BuildReason.None:
+      return 'None';
+    case BuildInterfaces.BuildReason.Manual:
+      return 'Manual';
+    case BuildInterfaces.BuildReason.IndividualCI:
+      return 'IndividualCI';
+    case BuildInterfaces.BuildReason.BatchedCI:
+      return 'BatchedCI';
+    case BuildInterfaces.BuildReason.Schedule:
+      return 'Schedule';
+    case BuildInterfaces.BuildReason.ScheduleForced:
+      return 'ScheduleForced';
+    case BuildInterfaces.BuildReason.UserCreated:
+      return 'UserCreated';
+    case BuildInterfaces.BuildReason.ValidateShelveset:
+      return 'ValidateShelveset';
+    case BuildInterfaces.BuildReason.CheckInShelveset:
+      return 'CheckInShelveset';
+    case BuildInterfaces.BuildReason.PullRequest:
+      return 'PullRequest';
+    case BuildInterfaces.BuildReason.BuildCompletion:
+      return 'BuildCompletion';
+    case BuildInterfaces.BuildReason.ResourceTrigger:
+      return 'ResourceTrigger';
+    default:
+      return `Unknown(${reason})`;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds BuildReason enum mapping to convert numeric reason values to human-readable strings
- Updates build_list tool to show descriptive reason values like "Manual", "Schedule", "PullRequest" instead of numeric codes

## Changes
- **New**: `mapBuildReason()` function in `src/utils/enum-mappers.ts`
- **Updated**: `build_list` tool in `src/tools/build-tools.ts` to use the new mapping
- **Improved**: User experience with more intuitive build reason display

## Example Output
**Before:**
```json
{
  "reason": 1
}
```

**After:**
```json
{
  "reason": "Manual"
}
```

## Test Plan
- [x] Built project successfully
- [x] Tested build_list tool output shows human-readable reason values
- [x] Verified mapping covers all standard BuildReason enum values

This builds on the previous enum mapping improvements and continues the effort to make all numeric Azure DevOps enum values human-readable for better user experience.