### PR TITLE
feat: add build_queue tool for launching builds

### DIFF
--- a/.changeset/build-reason-mapping.md
+++ b/.changeset/build-reason-mapping.md
@@ -1,0 +1,5 @@
+---
+"@rxreyn3/azure-devops-mcp": patch
+---
+
+Add BuildReason enum mapping to convert numeric reason values to human-readable strings in build_list output

--- a/.changeset/friendly-enum-values.md
+++ b/.changeset/friendly-enum-values.md
@@ -1,0 +1,5 @@
+---
+"@rxreyn3/azure-devops-mcp": patch
+---
+
+Convert numeric state and result values to human-readable strings in build_list and build_get_timeline outputs

--- a/.changeset/nervous-foxes-listen.md
+++ b/.changeset/nervous-foxes-listen.md
@@ -2,10 +2,19 @@
 "@rxreyn3/azure-devops-mcp": minor
 ---
 
-Add build_queue tool for launching builds programmatically
+Add `build_queue` tool for programmatically launching Azure DevOps builds
 
-- Added new `build_queue` tool that allows MCP clients to queue/launch builds
-- Supports configuring build parameters, source branch, build reason, agent demands, and specific queue targeting
-- Added `queueBuild` method to BuildClient with proper demand parsing
-- Updated documentation to clarify PAT requirements (needs both "Build (read & execute)" and "Agent Pools (read)" permissions)
-- Added sessions folder to .gitignore
+You can now queue builds directly from your MCP client without navigating to the Azure DevOps UI. The new `build_queue` tool supports all common build configuration options:
+
+- **Build parameters**: Pass custom parameters as key-value pairs (e.g., `{"maxScenes": "1"}`)
+- **Source branch**: Override the default branch (e.g., `"refs/heads/feature/my-branch"`)
+- **Build reason**: Specify why the build was triggered (Manual, IndividualCI, Schedule, etc.)
+- **Agent demands**: Target specific agent capabilities (e.g., `["Agent.OS -equals Windows_NT"]`)
+- **Queue selection**: Target a specific agent queue by ID
+
+**Important**: This tool requires your PAT to have both "Build (read & execute)" AND "Agent Pools (read)" permissions. The Agent Pools permission is necessary because Azure DevOps validates pool access when queuing builds.
+
+Example usage:
+```
+Ask your AI: "Queue a build for pipeline 2848 with maxScenes set to 1"
+```

--- a/.changeset/nervous-foxes-listen.md
+++ b/.changeset/nervous-foxes-listen.md
@@ -1,0 +1,11 @@
+---
+"@rxreyn3/azure-devops-mcp": minor
+---
+
+Add build_queue tool for launching builds programmatically
+
+- Added new `build_queue` tool that allows MCP clients to queue/launch builds
+- Supports configuring build parameters, source branch, build reason, agent demands, and specific queue targeting
+- Added `queueBuild` method to BuildClient with proper demand parsing
+- Updated documentation to clarify PAT requirements (needs both "Build (read & execute)" and "Agent Pools (read)" permissions)
+- Added sessions folder to .gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ logs/
 
 # Session files
 session_*.md
+sessions/
 
 # MCP configuration with credentials
 .mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,49 @@
-- use bun commands instead of npm:
-  - bun install instead of npm install
-  - bun run build instead of npm run build
-  - bun test instead of npm test
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Development Commands
+
+- `bun install` - Install dependencies
+- `bun run build` - Build TypeScript to dist/
+- `bun run dev` - Run in watch mode for development
+- `bun run typecheck` - Type check without emitting files
+- `bun run clean` - Remove dist directory
+- `bun run release` - Publish packages using changesets
+
+## Architecture Overview
+
+### Core Structure
+This is a Model Context Protocol (MCP) server for Azure DevOps, providing tools to interact with agents, queues, and builds.
+
+**Key Components:**
+- `src/server.ts` - Main MCP server class that handles tool registration and request routing
+- `src/index.ts` - Entry point that validates config and starts the server
+- `src/tools/` - Tool definitions split by domain (agent-tools.ts, build-tools.ts)
+- `src/clients/` - Azure DevOps API clients (TaskAgentClient, BuildClient) extending BaseClient
+- `src/types/` - TypeScript type definitions for tools, API responses, and domain models
+- `src/utils/` - Shared utilities for validation, error handling, formatting, and enum mapping
+
+### Tool Organization
+Tools are organized by Azure DevOps scope requirements:
+- **Project-scoped tools** (`project_*`) - Work with project-level PATs
+- **Organization-scoped tools** (`org_*`) - Require org-level permissions (agents exist at org level)
+- **Build tools** (`build_*`) - Access build timelines and execution details
+
+### Client Pattern
+All API clients extend `AdoBaseClient` which handles:
+- WebApi connection initialization
+- Common error handling patterns
+- Shared configuration
+
+### MCP Integration
+The server uses the Model Context Protocol SDK to:
+- Register available tools via `ListToolsRequestSchema`
+- Handle tool invocations via `CallToolRequestSchema`
+- Provide typed tool schemas with Zod validation
+
+## TypeScript Configuration
+- Target: ES2022 with NodeNext modules
+- Strict mode enabled
+- Source maps included for debugging
+- Declaration files generated for type exports

--- a/src/tools/build-tools.ts
+++ b/src/tools/build-tools.ts
@@ -1,6 +1,7 @@
 import { ToolDefinition } from '../types/tool-types.js';
 import { BuildClient } from '../clients/build-client.js';
 import { formatErrorResponse } from '../utils/formatters.js';
+import { mapBuildStatus, mapBuildResult, mapTimelineRecordState, mapTaskResult, mapBuildReason } from '../utils/enum-mappers.js';
 import * as BuildInterfaces from 'azure-devops-node-api/interfaces/BuildInterfaces.js';
 
 export function createBuildTools(client: BuildClient): Record<string, ToolDefinition> {
@@ -51,8 +52,8 @@ export function createBuildTools(client: BuildClient): Record<string, ToolDefini
               workerName: job.workerName,
               startTime: job.startTime,
               finishTime: job.finishTime,
-              state: job.state,
-              result: job.result,
+              state: mapTimelineRecordState(job.state),
+              result: mapTaskResult(job.result),
               percentComplete: job.percentComplete,
               id: job.id,
             })),
@@ -62,8 +63,8 @@ export function createBuildTools(client: BuildClient): Record<string, ToolDefini
               name: task.name,
               startTime: task.startTime,
               finishTime: task.finishTime,
-              state: task.state,
-              result: task.result,
+              state: mapTimelineRecordState(task.state),
+              result: mapTaskResult(task.result),
               percentComplete: task.percentComplete,
               parentId: task.parentId,
               id: task.id,
@@ -222,9 +223,9 @@ export function createBuildTools(client: BuildClient): Record<string, ToolDefini
             id: build.definition?.id,
             name: build.definition?.name,
           },
-          status: build.status,
-          result: build.result,
-          reason: build.reason,
+          status: mapBuildStatus(build.status),
+          result: mapBuildResult(build.result),
+          reason: mapBuildReason(build.reason),
           startTime: build.startTime,
           finishTime: build.finishTime,
           sourceBranch: build.sourceBranch,

--- a/src/utils/enum-mappers.ts
+++ b/src/utils/enum-mappers.ts
@@ -1,0 +1,127 @@
+import * as BuildInterfaces from 'azure-devops-node-api/interfaces/BuildInterfaces.js';
+
+/**
+ * Maps BuildStatus enum values to human-readable strings
+ */
+export function mapBuildStatus(status: BuildInterfaces.BuildStatus | undefined): string {
+  if (status === undefined || status === null) return 'Unknown';
+  
+  switch (status) {
+    case BuildInterfaces.BuildStatus.None:
+      return 'None';
+    case BuildInterfaces.BuildStatus.InProgress:
+      return 'InProgress';
+    case BuildInterfaces.BuildStatus.Completed:
+      return 'Completed';
+    case BuildInterfaces.BuildStatus.Cancelling:
+      return 'Cancelling';
+    case BuildInterfaces.BuildStatus.Postponed:
+      return 'Postponed';
+    case BuildInterfaces.BuildStatus.NotStarted:
+      return 'NotStarted';
+    case BuildInterfaces.BuildStatus.All:
+      return 'All';
+    default:
+      return `Unknown(${status})`;
+  }
+}
+
+/**
+ * Maps BuildResult enum values to human-readable strings
+ */
+export function mapBuildResult(result: BuildInterfaces.BuildResult | undefined): string {
+  if (result === undefined || result === null) return 'Unknown';
+  
+  switch (result) {
+    case BuildInterfaces.BuildResult.None:
+      return 'None';
+    case BuildInterfaces.BuildResult.Succeeded:
+      return 'Succeeded';
+    case BuildInterfaces.BuildResult.PartiallySucceeded:
+      return 'PartiallySucceeded';
+    case BuildInterfaces.BuildResult.Failed:
+      return 'Failed';
+    case BuildInterfaces.BuildResult.Canceled:
+      return 'Canceled';
+    default:
+      return `Unknown(${result})`;
+  }
+}
+
+/**
+ * Maps TimelineRecordState enum values to human-readable strings
+ */
+export function mapTimelineRecordState(state: BuildInterfaces.TimelineRecordState | undefined): string {
+  if (state === undefined || state === null) return 'Unknown';
+  
+  switch (state) {
+    case BuildInterfaces.TimelineRecordState.Pending:
+      return 'Pending';
+    case BuildInterfaces.TimelineRecordState.InProgress:
+      return 'InProgress';
+    case BuildInterfaces.TimelineRecordState.Completed:
+      return 'Completed';
+    default:
+      return `Unknown(${state})`;
+  }
+}
+
+/**
+ * Maps TaskResult enum values to human-readable strings
+ */
+export function mapTaskResult(result: BuildInterfaces.TaskResult | undefined): string {
+  if (result === undefined || result === null) return 'Unknown';
+  
+  switch (result) {
+    case BuildInterfaces.TaskResult.Succeeded:
+      return 'Succeeded';
+    case BuildInterfaces.TaskResult.SucceededWithIssues:
+      return 'SucceededWithIssues';
+    case BuildInterfaces.TaskResult.Failed:
+      return 'Failed';
+    case BuildInterfaces.TaskResult.Canceled:
+      return 'Canceled';
+    case BuildInterfaces.TaskResult.Skipped:
+      return 'Skipped';
+    case BuildInterfaces.TaskResult.Abandoned:
+      return 'Abandoned';
+    default:
+      return `Unknown(${result})`;
+  }
+}
+
+/**
+ * Maps BuildReason enum values to human-readable strings
+ */
+export function mapBuildReason(reason: BuildInterfaces.BuildReason | undefined): string {
+  if (reason === undefined || reason === null) return 'Unknown';
+  
+  switch (reason) {
+    case BuildInterfaces.BuildReason.None:
+      return 'None';
+    case BuildInterfaces.BuildReason.Manual:
+      return 'Manual';
+    case BuildInterfaces.BuildReason.IndividualCI:
+      return 'IndividualCI';
+    case BuildInterfaces.BuildReason.BatchedCI:
+      return 'BatchedCI';
+    case BuildInterfaces.BuildReason.Schedule:
+      return 'Schedule';
+    case BuildInterfaces.BuildReason.ScheduleForced:
+      return 'ScheduleForced';
+    case BuildInterfaces.BuildReason.UserCreated:
+      return 'UserCreated';
+    case BuildInterfaces.BuildReason.ValidateShelveset:
+      return 'ValidateShelveset';
+    case BuildInterfaces.BuildReason.CheckInShelveset:
+      return 'CheckInShelveset';
+    case BuildInterfaces.BuildReason.PullRequest:
+      return 'PullRequest';
+    case BuildInterfaces.BuildReason.BuildCompletion:
+      return 'BuildCompletion';
+    case BuildInterfaces.BuildReason.ResourceTrigger:
+      return 'ResourceTrigger';
+    default:
+      return `Unknown(${reason})`;
+  }
+}


### PR DESCRIPTION
## Summary
- Added new `build_queue` tool to programmatically launch Azure DevOps builds
- Supports all common build configuration options (parameters, branch, reason, demands, queue)
- Updated documentation with PAT permission requirements

## Details
This PR introduces the ability to queue builds directly through the MCP interface. Users can now launch builds with custom parameters without needing to navigate to the Azure DevOps UI.

### Key features:
- **Build parameters**: Pass custom parameters as key-value pairs
- **Source branch**: Override the default branch  
- **Build reason**: Specify why the build was triggered
- **Agent demands**: Target specific agent capabilities
- **Queue selection**: Target a specific agent queue by ID

### Important notes:
- Requires PAT with both "Build (read & execute)" AND "Agent Pools (read)" permissions
- The Agent Pools permission is needed because Azure DevOps validates pool access when queuing builds

## Test plan
- [x] Successfully queued a build for `Shotgrid.Render.Pipeline` with custom parameters
- [x] Verified error handling when PAT lacks required permissions
- [x] Updated documentation to clarify permission requirements
- [x] Type checking passes
- [x] Build completes successfully