### PR TITLE
feat: add flexible log download by name tool

### DIFF
--- a/.changeset/flexible-logs-download.md
+++ b/.changeset/flexible-logs-download.md
@@ -1,0 +1,9 @@
+---
+"@rxreyn3/azure-devops-mcp": minor
+---
+
+Add flexible log download by name tool
+
+Adds `build_download_logs_by_name` tool that searches for and downloads logs by name regardless of timeline record type. This eliminates the need to know whether "Deploy" or "Trigger Async Shift Upload" is a stage, job, or task.
+
+The tool automatically handles stages by downloading all child job logs into organized subdirectories, supports partial name matching, and provides clear feedback when multiple matches are found.

--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ These tools work with project-scoped PATs:
   - Validates job completion status before downloading
   - Returns saved file path, size, job details, and duration
 
+- **`build_download_logs_by_name`** - Download logs for a stage, job, or task by searching for its name in the build timeline (requires Build read)
+  - Required: buildId, name (e.g., "Deploy", "Trigger Async Shift Upload"), outputPath
+  - Optional: exactMatch (default: true) - set to false for partial/case-insensitive matching
+  - Automatically detects whether the name refers to a stage, job, or task
+  - For stages/phases: Downloads all child job logs into an organized directory structure
+  - For jobs: Downloads the job log (same as build_download_job_logs)
+  - For tasks: Downloads the individual task log with parent job context
+  - Handles multiple matches by showing all options and requesting clarification
+  - Returns downloaded log paths, sizes, and matched record details
+
 - **`build_list_artifacts`** - List all artifacts available for a specific build (requires Build read)
   - Required: buildId
   - Returns artifact names, IDs, types, and download URLs


### PR DESCRIPTION
## Summary
- Adds `build_download_logs_by_name` tool for flexible log downloads
- Automatically detects timeline record types (stage, job, task)
- Downloads all child job logs for stages into organized subdirectories

## Test plan
- [x] Tested downloading task logs (e.g., "Render All Scenes Sequentially")
- [x] Tested downloading stage logs (e.g., "SetupPipeline") - creates subdirectory with all child job logs
- [x] Tested partial name matching with exactMatch=false
- [x] Tested handling of ambiguous matches - shows all options
- [x] Verified 385KB task log and 28MB stage logs downloaded correctly